### PR TITLE
Add markdown and latex rendering support

### DIFF
--- a/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
@@ -69,6 +69,9 @@ import com.dark.tool_neuron.global.Standards
 
 val LocalCodeHighlightEnabled = compositionLocalOf { true }
 
+/** Debounce window (ms) for streaming markdown re-parsing. */
+private const val STREAMING_PARSE_DEBOUNCE_MS = 80L
+
 /**
  * Colors extracted once from MaterialTheme — passed to non-composable formatters
  * to avoid reading theme state inside every Text().
@@ -104,7 +107,7 @@ fun StreamingMarkdownText(text: String, modifier: Modifier = Modifier) {
 
     LaunchedEffect(Unit) {
         snapshotFlow { text }
-            .debounce(80)
+            .debounce(STREAMING_PARSE_DEBOUNCE_MS)
             .collect { latest ->
                 val result = withContext(Dispatchers.Default) { parseMarkdown(latest) }
                 parsedContent = result

--- a/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
@@ -96,6 +96,28 @@ fun MarkdownText(text: String, modifier: Modifier = Modifier) {
 }
 
 /**
+ * Streaming-optimised markdown renderer.
+ * Re-parses on every text change (bypasses the completed-message cache).
+ * Used in [AssistantStreamingBubble] so the user sees formatted text while
+ * tokens are still being generated.
+ */
+@Composable
+fun StreamingMarkdownText(text: String, modifier: Modifier = Modifier) {
+    val parsedContent = remember(text) { parseMarkdown(text) }
+    val colors = InlineColors(
+        codeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        highlightBg = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
+        mathColor = MaterialTheme.colorScheme.primary
+    )
+    Column(
+        modifier = modifier.padding(horizontal = Standards.SpacingXs),
+        verticalArrangement = Arrangement.spacedBy(Standards.SpacingXs)
+    ) {
+        parsedContent.forEach { element -> MarkdownElementView(element, colors) }
+    }
+}
+
+/**
  * Lazy version — each markdown element is a separate LazyList item.
  * Only visible items are composed. Use inside a LazyColumn.
  * Element-aware spacing: headings get more top padding, blocks get breathing room.
@@ -490,6 +512,20 @@ internal fun buildInlineFormatted(text: String, colors: InlineColors): Annotated
                     val rendered = renderMathToUnicode(text.substring(i + 1, end))
                     withStyle(SpanStyle(fontFamily = MapleMonoFontFamily, fontStyle = FontStyle.Italic, color = colors.mathColor)) { append(rendered) }
                     i = end + 1
+                } else { append(chars[i]); i++ }
+            }
+            // Markdown link [text](url)
+            chars[i] == '[' -> {
+                val closeBracket = text.indexOf(']', i + 1)
+                if (closeBracket != -1 && closeBracket + 1 < chars.size && chars[closeBracket + 1] == '(') {
+                    val closeParen = text.indexOf(')', closeBracket + 2)
+                    if (closeParen != -1) {
+                        val linkText = text.substring(i + 1, closeBracket)
+                        withStyle(SpanStyle(color = colors.mathColor, textDecoration = TextDecoration.Underline)) {
+                            append(buildInlineFormatted(linkText, colors))
+                        }
+                        i = closeParen + 1
+                    } else { append(chars[i]); i++ }
                 } else { append(chars[i]); i++ }
             }
             // Default — handle surrogates

--- a/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
@@ -522,7 +522,7 @@ internal fun buildInlineFormatted(text: String, colors: InlineColors): Annotated
                     if (closeParen != -1) {
                         val linkText = text.substring(i + 1, closeBracket)
                         withStyle(SpanStyle(color = colors.mathColor, textDecoration = TextDecoration.Underline)) {
-                            append(linkText)
+                            append(buildInlineFormatted(linkText, colors))
                         }
                         i = closeParen + 1
                     } else { append(chars[i]); i++ }

--- a/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
@@ -96,7 +96,7 @@ fun MarkdownText(text: String, modifier: Modifier = Modifier) {
 }
 
 /**
- * Streaming-optimised markdown renderer.
+ * Streaming-optimized markdown renderer.
  * Re-parses on every text change (bypasses the completed-message cache).
  * Used in [AssistantStreamingBubble] so the user sees formatted text while
  * tokens are still being generated.
@@ -522,7 +522,7 @@ internal fun buildInlineFormatted(text: String, colors: InlineColors): Annotated
                     if (closeParen != -1) {
                         val linkText = text.substring(i + 1, closeBracket)
                         withStyle(SpanStyle(color = colors.mathColor, textDecoration = TextDecoration.Underline)) {
-                            append(buildInlineFormatted(linkText, colors))
+                            append(linkText)
                         }
                         i = closeParen + 1
                     } else { append(chars[i]); i++ }

--- a/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/dark/tool_neuron/ui/components/MarkdownText.kt
@@ -24,11 +24,17 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -77,33 +83,40 @@ data class InlineColors(
 /**
  * Full markdown renderer for completed (non-streaming) messages.
  * Parses text into elements and renders each with appropriate styling.
- * Result is cached by [text] — stable for completed messages.
+ * Result is cached by [text] via the shared LRU parse cache.
  */
 @Composable
 fun MarkdownText(text: String, modifier: Modifier = Modifier) {
-    val parsedContent = remember(text) { parseMarkdown(text) }
-    val colors = InlineColors(
-        codeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-        highlightBg = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
-        mathColor = MaterialTheme.colorScheme.primary
-    )
-    Column(
-        modifier = modifier.padding(horizontal = Standards.SpacingXs),
-        verticalArrangement = Arrangement.spacedBy(Standards.SpacingXs)
-    ) {
-        parsedContent.forEach { element -> MarkdownElementView(element, colors) }
-    }
+    val parsedContent = remember(text) { parseMarkdownCached(text) }
+    MarkdownContent(parsedContent, modifier)
 }
 
 /**
  * Streaming-optimized markdown renderer.
- * Re-parses on every text change (bypasses the completed-message cache).
- * Used in [AssistantStreamingBubble] so the user sees formatted text while
- * tokens are still being generated.
+ * Debounces and parses off the main thread to avoid jank during rapid token
+ * updates (~50 ms cadence). Bypasses the completed-message LRU cache so that
+ * stale partial-text entries aren't retained after generation completes.
  */
+@OptIn(FlowPreview::class)
 @Composable
 fun StreamingMarkdownText(text: String, modifier: Modifier = Modifier) {
-    val parsedContent = remember(text) { parseMarkdown(text) }
+    var parsedContent by remember { mutableStateOf(parseMarkdown(text)) }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { text }
+            .debounce(80)
+            .collect { latest ->
+                val result = withContext(Dispatchers.Default) { parseMarkdown(latest) }
+                parsedContent = result
+            }
+    }
+
+    MarkdownContent(parsedContent, modifier)
+}
+
+/** Shared rendering core used by both [MarkdownText] and [StreamingMarkdownText]. */
+@Composable
+private fun MarkdownContent(elements: List<MarkdownElement>, modifier: Modifier = Modifier) {
     val colors = InlineColors(
         codeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
         highlightBg = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
@@ -113,7 +126,7 @@ fun StreamingMarkdownText(text: String, modifier: Modifier = Modifier) {
         modifier = modifier.padding(horizontal = Standards.SpacingXs),
         verticalArrangement = Arrangement.spacedBy(Standards.SpacingXs)
     ) {
-        parsedContent.forEach { element -> MarkdownElementView(element, colors) }
+        elements.forEach { element -> MarkdownElementView(element, colors) }
     }
 }
 

--- a/app/src/main/java/com/dark/tool_neuron/ui/screen/home/MessageBubbles.kt
+++ b/app/src/main/java/com/dark/tool_neuron/ui/screen/home/MessageBubbles.kt
@@ -78,22 +78,20 @@ internal fun AssistantStreamingBubble(text: String) {
             )
         }
 
-        if (parsedMessage.actualContent.isNotEmpty()) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(Standards.SpacingSm),
-                verticalAlignment = Alignment.Top
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(8.dp)
-                        .background(MaterialTheme.colorScheme.primary, shape = CircleShape)
-                )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(Standards.SpacingSm),
+            verticalAlignment = Alignment.Top
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(MaterialTheme.colorScheme.primary, shape = CircleShape)
+            )
 
-                StreamingMarkdownText(
-                    text = parsedMessage.actualContent.ifEmpty { "..." },
-                    modifier = Modifier.weight(1f)
-                )
-            }
+            StreamingMarkdownText(
+                text = parsedMessage.actualContent.ifEmpty { "..." },
+                modifier = Modifier.weight(1f)
+            )
         }
     }
 }

--- a/app/src/main/java/com/dark/tool_neuron/ui/screen/home/MessageBubbles.kt
+++ b/app/src/main/java/com/dark/tool_neuron/ui/screen/home/MessageBubbles.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.dark.tool_neuron.models.messages.Messages
 import com.dark.tool_neuron.ui.components.ExpandCollapseIcon
 import com.dark.tool_neuron.ui.components.MarkdownText
+import com.dark.tool_neuron.ui.components.StreamingMarkdownText
 import com.dark.tool_neuron.ui.icons.TnIcons
 import com.dark.tool_neuron.ui.theme.Motion
 import java.util.Base64
@@ -88,10 +89,8 @@ internal fun AssistantStreamingBubble(text: String) {
                         .background(MaterialTheme.colorScheme.primary, shape = CircleShape)
                 )
 
-                Text(
+                StreamingMarkdownText(
                     text = parsedMessage.actualContent.ifEmpty { "..." },
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f)
                 )
             }


### PR DESCRIPTION
This pull request introduces a streaming-optimized markdown renderer to improve performance and responsiveness during rapid token updates in chat messages. The main changes include adding a new `StreamingMarkdownText` composable, updating message bubble rendering to use this for streaming assistant messages, and enhancing markdown parsing with link support.

**Streaming markdown rendering improvements:**

* Added `StreamingMarkdownText` composable in `MarkdownText.kt`, which debounces input and parses markdown off the main thread for smoother UI during streaming messages. This bypasses the LRU cache to prevent stale partial entries. 

* Updated `AssistantStreamingBubble` in `MessageBubbles.kt` to use `StreamingMarkdownText` instead of plain `Text`, improving the rendering of assistant messages as they stream in. 

**Markdown parsing enhancements:**

* Improved inline markdown formatting in `buildInlineFormatted` to support links with `[text](url)` syntax, displaying them with underline and custom color. 

**Code structure and performance:**

* Introduced a debounce constant (`STREAMING_PARSE_DEBOUNCE_MS`) for controlling streaming parse frequency. 

* Refactored markdown rendering core into a shared `MarkdownContent` composable for both completed and streaming 

These changes collectively enhance the user experience for streaming chat messages and add markdown link support.
closes #86